### PR TITLE
Update & maintenance

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,6 @@ indent_style = tab
 indent_size = tab
 tab_width = 4
 
-[{*.json, *.yaml, *.yml, *.md}]
+[*.{json,yaml,yml,md}]
 indent_style = space
 indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,10 @@
-# Not archived
 .docs export-ignore
-tests export-ignore
 .editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .travis.yml export-ignore
 Makefile export-ignore
-phpstan.neon export-ignore
 README.md export-ignore
+phpstan.neon export-ignore
 ruleset.xml export-ignore
+tests export-ignore

--- a/.github/workflows/codesniffer.yml
+++ b/.github/workflows/codesniffer.yml
@@ -2,6 +2,7 @@ name: "Codesniffer"
 
 on:
   pull_request:
+  workflow_dispatch:
 
   push:
     branches: ["*"]
@@ -12,4 +13,6 @@ on:
 jobs:
   codesniffer:
     name: "Codesniffer"
-    uses: contributte/.github/.github/workflows/codesniffer.yml@v1
+    uses: contributte/.github/.github/workflows/codesniffer.yml@master
+    with:
+      php: "8.4"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,14 +2,17 @@ name: "Coverage"
 
 on:
   pull_request:
+  workflow_dispatch:
 
   push:
     branches: ["*"]
 
   schedule:
-    - cron: "0 8 * * 1"
+    - cron: "0 9 * * 1"
 
 jobs:
   coverage:
     name: "Nette Tester"
-    uses: contributte/.github/.github/workflows/nette-tester-coverage.yml@v1
+    uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
+    with:
+      php: "8.4"

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -2,14 +2,17 @@ name: "Phpstan"
 
 on:
   pull_request:
+  workflow_dispatch:
 
   push:
     branches: ["*"]
 
   schedule:
-    - cron: "0 8 * * 1"
+    - cron: "0 10 * * 1"
 
 jobs:
   phpstan:
     name: "Phpstan"
-    uses: contributte/.github/.github/workflows/phpstan.yml@v1
+    uses: contributte/.github/.github/workflows/phpstan.yml@master
+    with:
+      php: "8.4"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,35 +2,42 @@ name: "Nette Tester"
 
 on:
   pull_request:
+  workflow_dispatch:
 
   push:
     branches: [ "*" ]
 
   schedule:
-    - cron: "0 8 * * 1"
+    - cron: "0 10 * * 1"
 
 jobs:
+  test85:
+    name: "Nette Tester"
+    uses: contributte/.github/.github/workflows/nette-tester.yml@master
+    with:
+      php: "8.5"
+
+  test84:
+    name: "Nette Tester"
+    uses: contributte/.github/.github/workflows/nette-tester.yml@master
+    with:
+      php: "8.4"
+
+  test83:
+    name: "Nette Tester"
+    uses: contributte/.github/.github/workflows/nette-tester.yml@master
+    with:
+      php: "8.3"
+
   test82:
     name: "Nette Tester"
-    uses: contributte/.github/.github/workflows/nette-tester.yml@v1
+    uses: contributte/.github/.github/workflows/nette-tester.yml@master
     with:
       php: "8.2"
 
-  test81:
-    name: "Nette Tester"
-    uses: contributte/.github/.github/workflows/nette-tester.yml@v1
-    with:
-      php: "8.1"
-
-  test80:
-    name: "Nette Tester"
-    uses: contributte/.github/.github/workflows/nette-tester.yml@v1
-    with:
-      php: "8.0"
-
   testlower:
     name: "Nette Tester"
-    uses: contributte/.github/.github/workflows/nette-tester.yml@v1
+    uses: contributte/.github/.github/workflows/nette-tester.yml@master
     with:
       php: "8.0"
       composer: "composer update --no-interaction --no-progress --prefer-dist --prefer-stable --prefer-lowest"

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,9 @@
 /composer.lock
 
 # Tests
-/temp
-/coverage.xml
+/tests/tmp
+/coverage.*
+/tests/**/*.log
+/tests/**/*.html
+/tests/**/*.expected
+/tests/**/*.actual

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
-.PHONY: install qa cs csf phpstan tests coverage
-
+.PHONY: install
 install:
 	composer update
 
+.PHONY: qa
 qa: phpstan cs
 
+.PHONY: cs
 cs:
 ifdef GITHUB_ACTION
 	vendor/bin/phpcs --standard=ruleset.xml --encoding=utf-8 --extensions="php,phpt" --colors -nsp -q --report=checkstyle src tests | cs2pr
@@ -12,15 +13,19 @@ else
 	vendor/bin/phpcs --standard=ruleset.xml --encoding=utf-8 --extensions="php,phpt" --colors -nsp src tests
 endif
 
+.PHONY: csf
 csf:
-	vendor/bin/phpcbf --standard=ruleset.xml --encoding=utf-8 --colors -nsp src tests
+	vendor/bin/phpcbf --standard=ruleset.xml --encoding=utf-8 --extensions="php,phpt" --colors -nsp src tests
 
+.PHONY: phpstan
 phpstan:
 	vendor/bin/phpstan analyse -c phpstan.neon
 
+.PHONY: tests
 tests:
 	vendor/bin/tester -s -p php --colors 1 -C tests/Cases
 
+.PHONY: coverage
 coverage:
 ifdef GITHUB_ACTION
 	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,9 @@
     "nette/utils": "^3.2.9 || ^4.0.0"
   },
   "require-dev": {
-    "contributte/tester": "^0.2.0",
+    "contributte/phpstan": "^0.2.0",
     "contributte/qa": "^0.4.0",
-    "phpstan/phpstan": "^1.0",
-    "phpstan/phpstan-deprecation-rules": "^1.0",
-    "phpstan/phpstan-nette": "^1.0",
-    "phpstan/phpstan-strict-rules": "^1.0"
+    "contributte/tester": "^0.3.0"
   },
   "autoload": {
     "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,12 +1,9 @@
 includes:
-	- vendor/phpstan/phpstan-deprecation-rules/rules.neon
-	- vendor/phpstan/phpstan-nette/extension.neon
-	- vendor/phpstan/phpstan-nette/rules.neon
-	- vendor/phpstan/phpstan-strict-rules/rules.neon
+	- vendor/contributte/phpstan/phpstan.neon
 
 parameters:
 	level: 9
-	phpVersion: 70400
+	phpVersion: 80200
 
 	scanDirectories:
 		- src
@@ -19,11 +16,6 @@ parameters:
 
 	ignoreErrors:
 		-
-			message: "#^Cannot access an offset on iterable\\<callable\\>\\.$#"
-			count: 1
-			path: src/PluggableConfigurator.php
-
-		-
-			message: "#^Parameter \\#1 \\$function of function call_user_func_array expects callable\\(\\)\\: mixed, array\\{Contributte\\\\Bootstrap\\\\Plugin\\\\IPlugin, 'plugin'\\} given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of function call_user_func_array expects callable\\(\\)\\: mixed, array\\{Contributte\\\\Bootstrap\\\\Plugin\\\\IPlugin, 'plugin'\\} given\\.$#"
 			count: 1
 			path: src/PluggableConfigurator.php

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ruleset
-	name="Contributte"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd"
->
+<ruleset name="Contributte" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
 	<!-- Rulesets -->
-	<rule ref="./vendor/contributte/qa/ruleset-8.0.xml"/>
+	<rule ref="./vendor/contributte/qa/ruleset-8.2.xml"/>
 
-	<!-- Specific rules -->
+	<!-- Rules -->
 	<rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
 		<properties>
 			<property name="rootNamespaces" type="array">
@@ -21,6 +17,6 @@
 		<exclude-pattern>/tests</exclude-pattern>
 	</rule>
 
-	<!-- Exclude folders -->
+	<!-- Excludes -->
 	<exclude-pattern>/tests/tmp</exclude-pattern>
 </ruleset>

--- a/tests/Cases/ExtraConfigurator.parseCase.phpt
+++ b/tests/Cases/ExtraConfigurator.parseCase.phpt
@@ -2,34 +2,36 @@
 
 namespace Tests;
 
+use Contributte\Tester\Environment;
 use Contributte\Tester\Toolkit;
 use Tester\Assert;
+use Tests\Fixtures\Helpers;
 use Tests\Fixtures\MockExtraConfigurator;
 
 require_once __DIR__ . '/../bootstrap.php';
 
 Toolkit::test(function (): void {
 	$_SERVER = [];
-	env('NETTE__USer', 'felix');
+	Helpers::env('NETTE__USer', 'felix');
 
 	// LOWERCASE
 	$configurator = new MockExtraConfigurator();
 	$configurator->addEnvParameters();
-	$configurator->setTempDirectory(TEMP_DIR);
+	$configurator->setTempDirectory(Environment::getTestDir());
 	$container = $configurator->createContainer();
 	Assert::equal('felix', $container->getParameters()['user']);
 
 	// UPPERCASE
 	$configurator->setParseCase($configurator::PARSE_UPPERCASE);
 	$configurator->addEnvParameters();
-	$configurator->setTempDirectory(TEMP_DIR);
+	$configurator->setTempDirectory(Environment::getTestDir());
 	$container = $configurator->createContainer();
 	Assert::equal('felix', $container->getParameters()['USER']);
 
 	// NATURAL
 	$configurator->setParseCase($configurator::PARSE_NATURAL);
 	$configurator->addEnvParameters();
-	$configurator->setTempDirectory(TEMP_DIR);
+	$configurator->setTempDirectory(Environment::getTestDir());
 	$container = $configurator->createContainer();
 	Assert::equal('felix', $container->getParameters()['USer']);
 });

--- a/tests/Cases/ExtraConfigurator.parseDelimiter.phpt
+++ b/tests/Cases/ExtraConfigurator.parseDelimiter.phpt
@@ -2,21 +2,23 @@
 
 namespace Tests;
 
+use Contributte\Tester\Environment;
 use Contributte\Tester\Toolkit;
 use Tester\Assert;
+use Tests\Fixtures\Helpers;
 use Tests\Fixtures\MockExtraConfigurator;
 
 require_once __DIR__ . '/../bootstrap.php';
 
 Toolkit::test(function (): void {
 	$_SERVER = [];
-	env('NETTE.DATABASE.HOST', 'localhost');
+	Helpers::env('NETTE.DATABASE.HOST', 'localhost');
 
 	$configurator = new MockExtraConfigurator();
 	$configurator->setParseDelimiter('.');
 	$configurator->addEnvParameters();
 
-	$configurator->setTempDirectory(TEMP_DIR);
+	$configurator->setTempDirectory(Environment::getTestDir());
 	$container = $configurator->createContainer();
 
 	Assert::equal('localhost', $container->getParameters()['database']['host']);

--- a/tests/Cases/ExtraConfigurator.parseParameters.phpt
+++ b/tests/Cases/ExtraConfigurator.parseParameters.phpt
@@ -5,10 +5,11 @@ namespace Tests;
 use Contributte\Bootstrap\ExtraConfigurator;
 use Contributte\Tester\Toolkit;
 use Tester\Assert;
+use Tests\Fixtures\Helpers;
 
 require_once __DIR__ . '/../bootstrap.php';
 
 Toolkit::test(function (): void {
-	env('NETTE__TOKEN', '123456');
+	Helpers::env('NETTE__TOKEN', '123456');
 	Assert::equal(ExtraConfigurator::parseParameters($_SERVER, 'NETTE__'), ['token' => '123456']);
 });

--- a/tests/Cases/ExtraConfigurator.phpt
+++ b/tests/Cases/ExtraConfigurator.phpt
@@ -2,8 +2,10 @@
 
 namespace Tests;
 
+use Contributte\Tester\Environment;
 use Contributte\Tester\Toolkit;
 use Tester\Assert;
+use Tests\Fixtures\Helpers;
 use Tests\Fixtures\MockExtraConfigurator;
 
 require_once __DIR__ . '/../bootstrap.php';
@@ -11,9 +13,9 @@ require_once __DIR__ . '/../bootstrap.php';
 // Parsing NETTE__ parameters
 Toolkit::test(function (): void {
 	$_SERVER = [];
-	env('NETTE__FOOBAR__BAR', 'foobar1');
-	env('NETTE__FOOBAR__BAZ', 'foobar2');
-	env('NETTE_INVALID', 'foobar3');
+	Helpers::env('NETTE__FOOBAR__BAR', 'foobar1');
+	Helpers::env('NETTE__FOOBAR__BAZ', 'foobar2');
+	Helpers::env('NETTE_INVALID', 'foobar3');
 
 	$configurator = new MockExtraConfigurator();
 
@@ -28,9 +30,9 @@ Toolkit::test(function (): void {
 // Parsing all ENV parameters
 Toolkit::test(function (): void {
 	$_SERVER = [];
-	env('NETTE__FOOBAR__BAR', 'foobar1');
-	env('NETTE_INVALID', 'foobar3');
-	env('X', 'Y');
+	Helpers::env('NETTE__FOOBAR__BAR', 'foobar1');
+	Helpers::env('NETTE_INVALID', 'foobar3');
+	Helpers::env('X', 'Y');
 
 	$configurator = new MockExtraConfigurator();
 
@@ -46,36 +48,36 @@ Toolkit::test(function (): void {
 	$_SERVER = [];
 	$configurator = new MockExtraConfigurator();
 
-	env('NETTE_DEBUG', true);
+	Helpers::env('NETTE_DEBUG', true);
 	$configurator->setEnvDebugMode();
 	Assert::true($configurator->isDebugMode());
 
-	env('NETTE_DEBUG', 'true');
+	Helpers::env('NETTE_DEBUG', 'true');
 	$configurator->setEnvDebugMode();
 	Assert::true($configurator->isDebugMode());
 
-	env('NETTE_DEBUG', '1');
+	Helpers::env('NETTE_DEBUG', '1');
 	$configurator->setEnvDebugMode();
 	Assert::true($configurator->isDebugMode());
 
-	env('NETTE_DEBUG', false);
+	Helpers::env('NETTE_DEBUG', false);
 	$configurator->setEnvDebugMode();
 	Assert::false($configurator->isDebugMode());
 
-	env('NETTE_DEBUG', 'false');
+	Helpers::env('NETTE_DEBUG', 'false');
 	$configurator->setEnvDebugMode();
 	Assert::false($configurator->isDebugMode());
 
-	env('NETTE_DEBUG', '0');
+	Helpers::env('NETTE_DEBUG', '0');
 	$configurator->setEnvDebugMode();
 	Assert::false($configurator->isDebugMode());
 
-	env('NETTE_DEBUG', 'foobar');
+	Helpers::env('NETTE_DEBUG', 'foobar');
 	$configurator->setEnvDebugMode();
 	Assert::false($configurator->isDebugMode());
 
-	env('NETTE_DEBUG', '10.0.0.1');
-	env('REMOTE_ADDR', '10.0.0.1');
+	Helpers::env('NETTE_DEBUG', '10.0.0.1');
+	Helpers::env('REMOTE_ADDR', '10.0.0.1');
 	$configurator->setEnvDebugMode();
 	Assert::true($configurator->isDebugMode());
 });
@@ -84,7 +86,7 @@ Toolkit::test(function (): void {
 Toolkit::test(function (): void {
 	$configurator = new MockExtraConfigurator();
 	$configurator->setDebugMode(false);
-	$fileName = TEMP_DIR . '/.debug';
+	$fileName = Environment::getTestDir() . '/.debug';
 
 	touch($fileName);
 	$configurator->setFileDebugMode($fileName);
@@ -123,7 +125,7 @@ Toolkit::test(function (): void {
 // Passing parameters to configurator
 Toolkit::test(function (): void {
 	$_SERVER = [];
-	env('NETTE__DATABASE__HOST', 'localhost');
+	Helpers::env('NETTE__DATABASE__HOST', 'localhost');
 
 	$configurator = new MockExtraConfigurator();
 	$configurator->addEnvParameters();
@@ -131,7 +133,7 @@ Toolkit::test(function (): void {
 		'foobar' => '%database.host%',
 	]);
 
-	$configurator->setTempDirectory(TEMP_DIR);
+	$configurator->setTempDirectory(Environment::getTestDir());
 	$container = $configurator->createContainer();
 
 	Assert::equal('localhost', $container->getParameters()['database']['host']);

--- a/tests/Cases/PluggableConfigurator.phpt
+++ b/tests/Cases/PluggableConfigurator.phpt
@@ -3,8 +3,9 @@
 namespace Tests;
 
 use Contributte\Bootstrap\PluggableConfigurator;
-use Contributte\Tester\Notes;
+use Contributte\Tester\Environment;
 use Contributte\Tester\Toolkit;
+use Contributte\Tester\Utils\Notes;
 use Tester\Assert;
 use Tests\Fixtures\MockContainerPlugin;
 use Tests\Fixtures\MockDebugContainerPlugin;
@@ -13,7 +14,7 @@ require_once __DIR__ . '/../bootstrap.php';
 
 Toolkit::test(function (): void {
 	$pluggable = new PluggableConfigurator();
-	$pluggable->setTempDirectory(TEMP_DIR);
+	$pluggable->setTempDirectory(Environment::getTestDir());
 
 	$pluggable->addPlugin(new MockContainerPlugin());
 	$pluggable->addPlugin(new MockDebugContainerPlugin());
@@ -26,7 +27,7 @@ Toolkit::test(function (): void {
 
 Toolkit::test(function (): void {
 	$pluggable = new PluggableConfigurator();
-	$pluggable->setTempDirectory(TEMP_DIR);
+	$pluggable->setTempDirectory(Environment::getTestDir());
 	unset($pluggable->defaultExtensions['di']);
 
 	$pluggable->addPlugin(new MockContainerPlugin());

--- a/tests/Fixtures/Helpers.php
+++ b/tests/Fixtures/Helpers.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Fixtures;
+
+final class Helpers
+{
+
+	public static function env(string $key, string|float|bool $value): void
+	{
+		$_SERVER[$key] = $value;
+		putenv(sprintf('%s=%s', $key, $value));
+	}
+
+}

--- a/tests/Fixtures/MockContainerPlugin.php
+++ b/tests/Fixtures/MockContainerPlugin.php
@@ -3,7 +3,7 @@
 namespace Tests\Fixtures;
 
 use Contributte\Bootstrap\Plugin\IContainerPlugin;
-use Contributte\Tester\Notes;
+use Contributte\Tester\Utils\Notes;
 use Nette\Bootstrap\Configurator;
 use Nette\DI\Container;
 

--- a/tests/Fixtures/MockDebugContainerPlugin.php
+++ b/tests/Fixtures/MockDebugContainerPlugin.php
@@ -3,7 +3,7 @@
 namespace Tests\Fixtures;
 
 use Contributte\Bootstrap\Plugin\IDebugContainerPlugin;
-use Contributte\Tester\Notes;
+use Contributte\Tester\Utils\Notes;
 use Nette\Bootstrap\Configurator;
 use Nette\DI\Container;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,13 +7,4 @@ if (@!include __DIR__ . '/../vendor/autoload.php') {
 	exit(1);
 }
 
-// Configure environment
-Environment::setupTester();
-Environment::setupTimezone();
-Environment::setupVariables(__DIR__);
-
-function env(string $key, string|float|bool $value): void
-{
-	$_SERVER[$key] = $value;
-	putenv(sprintf('%s=%s', $key, $value));
-}
+Environment::setup(__DIR__);


### PR DESCRIPTION
- Replace phpstan/* packages with contributte/phpstan
- Update contributte/tester to ^0.3.0
- Update phpstan.neon to use contributte/phpstan preset
- Update ruleset.xml to use ruleset-8.2.xml
- Update Makefile with separate .PHONY declarations
- Update GitHub workflows to use @master and add workflow_dispatch
- Update .editorconfig glob pattern format
- Update .gitignore with comprehensive test patterns
- Update tests/bootstrap.php for new tester version
- Add Notes fixture for plugin testing compatibility