### PR TITLE
CI: switch coverage reporting to Codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
   <a href="https://github.com/contributte/bootstrap/actions">
     <img src="https://badgen.net/github/checks/contributte/bootstrap/master?cache=300">
   </a>
-  <a href="https://coveralls.io/r/contributte/bootstrap">
-    <img src="https://badgen.net/coveralls/c/github/contributte/bootstrap?cache=300">
+  <a href="https://codecov.io/gh/contributte/bootstrap">
+    <img src="https://badgen.net/codecov/c/github/contributte/bootstrap?cache=300">
   </a>
   <a href="https://packagist.org/packages/contributte/bootstrap">
     <img src="https://badgen.net/packagist/dm/contributte/bootstrap">

--- a/tests/.coveralls.yml
+++ b/tests/.coveralls.yml
@@ -1,4 +1,0 @@
-# for php-coveralls
-service_name: github-actions
-coverage_clover: coverage.xml
-json_path: coverage.json


### PR DESCRIPTION
## Summary
- replace the README Coveralls badge with Codecov
- remove the obsolete `tests/.coveralls.yml` file
- keep the repository aligned with the shared Codecov coverage setup

## Related
- contributte/contributte#72