### PR TITLE
Remove phpdbg from coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tests:
 .PHONY: coverage
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary

Replace the `coverage` target in `Makefile` to run Tester with `php` instead of `phpdbg`.

## Motivation

This repo is part of the org-wide migration tracked in contributte/contributte#73 so coverage runs no longer depend on `phpdbg`.

## Changes

- switch both CI and local `coverage` target variants from `-p phpdbg` to `-p php`

## Testing

- [ ] Tests pass locally
- [ ] CI passes
- [ ] Manual verification (if applicable)
- attempted `make coverage`, but this checkout does not have `vendor/bin/tester` installed yet