### PR TITLE
CI: inherit secrets in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,5 +14,6 @@ jobs:
   coverage:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
+    secrets: inherit
     with:
       php: "8.4"


### PR DESCRIPTION
## What changed

- add `secrets: inherit` to `.github/workflows/coverage.yml` for the reusable coverage workflow call

## Why

- ensure the reusable coverage workflow receives inherited secrets required for the issue 74 rollout
- relates to contributte/contributte#74