### PR TITLE
CI: inherit secrets in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,5 +14,6 @@ jobs:
   coverage:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
+    secrets: inherit
     with:
       php: "8.4"


### PR DESCRIPTION
## What changed
- added `secrets: inherit` to the reusable coverage workflow job

## Why
- allows the called coverage workflow to receive required repository secrets for reporting

contributte/contributte#74